### PR TITLE
Add missing runtime dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ if __name__ == "__main__":
                      'Operating System :: MacOS'],
         platforms='any',
         packages=['mne_rsa'],
-        install_requires=['numpy', 'scipy', 'matplotlib', 'mne'],
+        install_requires=['numpy', 'scipy', 'scikit-learn', 'nibabel',
+                          'matplotlib', 'mne'],
     )


### PR DESCRIPTION
`nibabel` and `scikit-learn` are required to import the package.