### PR TITLE
1D data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,31 +62,29 @@ Juicy bits of the API
 
 .. code:: python
 
-   def compute_dsm(model, pca=False, metric='correlation', **kwargs)
+   def compute_dsm(data, metric='correlation', **kwargs)
 
-   def rsa_stcs(stcs, model_dsm, src, y=None,
-                spatial_radius=0.04, temporal_radius=0.1,
-                stc_dsm_metric='correlation', stc_dsm_params=None,
-                rsa_metric='spearman',
-                n_jobs=1, verbose=False)
+   def rsa_stcs(stcs, dsm_model, src, spatial_radius=0.04, temporal_radius=0.1,
+                stc_dsm_metric='correlation', stc_dsm_params=dict(),
+                rsa_metric='spearman', y=None, n_folds=1, sel_vertices=None,
+                tmin=None, tmax=None, n_jobs=1, verbose=False):
 
-   def rsa_evokeds(evokeds, model_dsm, y=None, noise_cov=None,
-                   spatial_radius=0.04, temporal_radius=0.1,
-                   evoked_dsm_metric='correlation', evoked_dsm_params=None,
-                   rsa_metric='spearman',
-                   n_jobs=1, verbose=False)
+   def rsa_evokeds(evokeds, dsm_model, noise_cov=None, spatial_radius=0.04,
+                   temporal_radius=0.1, evoked_dsm_metric='correlation',
+                   evoked_dsm_params=dict(), rsa_metric='spearman', y=None,
+                   n_folds=1, picks=None, tmin=None, tmax=None, n_jobs=1,
+                   verbose=False):
 
-   def rsa_epochs(epochs, model_dsm, y=None, noise_cov=None,
-                  spatial_radius=0.04, temporal_radius=0.1,
-                  epochs_dsm_metric='correlation', epochs_dsm_params=None,
-                  rsa_metric='spearman',
-                  n_jobs=1, verbose=False)
+   def rsa_epochs(epochs, dsm_model, noise_cov=None, spatial_radius=0.04,
+                  temporal_radius=0.1, epochs_dsm_metric='correlation',
+                  epochs_dsm_params=dict(), rsa_metric='spearman', y=None,
+                  n_folds=1, picks=None, tmin=None, tmax=None, n_jobs=1,
+                  verbose=False):
 
-   def rsa_nifti(image, model_dsm, src, y=None,
-                 spatial_radius=0.01, 
-                 image_dsm_metric='correlation', image_dsm_params=None,
-                 rsa_metric='spearman',
-                 n_jobs=1, verbose=False)
+   def rsa_nifti(image, dsm_model, spatial_radius=0.01,
+                 image_dsm_metric='correlation', image_dsm_params=dict(),
+                 rsa_metric='spearman', y=None, n_folds=1, roi_mask=None,
+                 brain_mask=None, n_jobs=1, verbose=False):
 
 Example usage
 -------------

--- a/mne_rsa/sensor_level.py
+++ b/mne_rsa/sensor_level.py
@@ -201,11 +201,11 @@ def rsa_evokeds(evokeds, dsm_model, noise_cov=None, spatial_radius=0.04,
                            temporal_radius)
 
     if one_model:
-        return mne.EvokedArray(data[:, :, 0], info, tmin, comment='RSA',
-                               nave=len(evokeds))
+        return mne.EvokedArray(np.atleast_2d(data[..., 0]), info, tmin,
+                               comment='RSA', nave=len(evokeds))
     else:
-        return [mne.EvokedArray(data[:, :, i], info, tmin, comment='RSA',
-                                nave=len(evokeds))
+        return [mne.EvokedArray(np.atleast_2d(data[..., i]), info, tmin,
+                                comment='RSA', nave=len(evokeds))
                 for i in range(data.shape[-1])]
 
 
@@ -382,11 +382,11 @@ def rsa_epochs(epochs, dsm_model, noise_cov=None, spatial_radius=0.04,
                            temporal_radius)
 
     if one_model:
-        return mne.EvokedArray(data, info, tmin, comment='RSA',
+        return mne.EvokedArray(np.atleast_2d(data), info, tmin, comment='RSA',
                                nave=len(np.unique(y)))
     else:
-        return [mne.EvokedArray(data[:, :, i], info, tmin, comment='RSA',
-                                nave=len(np.unique(y)))
+        return [mne.EvokedArray(np.atleast_2d(data[..., i]), info, tmin,
+                                comment='RSA', nave=len(np.unique(y)))
                 for i in range(data.shape[-1])]
 
 

--- a/mne_rsa/source_level.py
+++ b/mne_rsa/source_level.py
@@ -182,19 +182,22 @@ def rsa_stcs(stcs, dsm_model, src, spatial_radius=0.04, temporal_radius=0.1,
 
     if one_model:
         if src.kind == 'volume':
-            return mne.VolSourceEstimate(data, vertices, tmin, tstep,
-                                         subject=stcs[0].subject)
+            return mne.VolSourceEstimate(
+                np.atleast_2d(data), vertices, tmin, tstep,
+                subject=stcs[0].subject)
         else:
-            return mne.SourceEstimate(data, vertices, tmin, tstep,
-                                      subject=stcs[0].subject)
+            return mne.SourceEstimate(
+                np.atleast_2d(data), vertices, tmin, tstep,
+                subject=stcs[0].subject)
     else:
         if src.kind == 'volume':
-            return [mne.VolSourceEstimate(data[:, :, i], vertices, tmin, tstep,
+            return [mne.VolSourceEstimate(np.atleast_2d(data[..., i]),
+                                          vertices, tmin, tstep,
                                           subject=stcs[0].subject)
                     for i in range(data.shape[-1])]
         else:
-            return [mne.SourceEstimate(data[:, :, i], vertices, tmin, tstep,
-                                       subject=stcs[0].subject)
+            return [mne.SourceEstimate(np.atleast_2d(data[..., i]), vertices,
+                                       tmin, tstep, subject=stcs[0].subject)
                     for i in range(data.shape[-1])]
 
 

--- a/mne_rsa/source_level.py
+++ b/mne_rsa/source_level.py
@@ -182,22 +182,19 @@ def rsa_stcs(stcs, dsm_model, src, spatial_radius=0.04, temporal_radius=0.1,
 
     if one_model:
         if src.kind == 'volume':
-            return mne.VolSourceEstimate(
-                np.atleast_2d(data), vertices, tmin, tstep,
-                subject=stcs[0].subject)
+            return mne.VolSourceEstimate(data, vertices, tmin, tstep,
+                                         subject=stcs[0].subject)
         else:
-            return mne.SourceEstimate(
-                np.atleast_2d(data), vertices, tmin, tstep,
-                subject=stcs[0].subject)
+            return mne.SourceEstimate(data, vertices, tmin, tstep,
+                                      subject=stcs[0].subject)
     else:
         if src.kind == 'volume':
-            return [mne.VolSourceEstimate(np.atleast_2d(data[..., i]),
-                                          vertices, tmin, tstep,
+            return [mne.VolSourceEstimate(data[..., i], vertices, tmin, tstep,
                                           subject=stcs[0].subject)
                     for i in range(data.shape[-1])]
         else:
-            return [mne.SourceEstimate(np.atleast_2d(data[..., i]), vertices,
-                                       tmin, tstep, subject=stcs[0].subject)
+            return [mne.SourceEstimate(data[..., i], vertices, tmin, tstep,
+                                       subject=stcs[0].subject)
                     for i in range(data.shape[-1])]
 
 


### PR DESCRIPTION
When the RSA result is one-dimensional, it cannot be readily packed inside an `mne.Evokeds` or `mne.SourceEstimate` object. This PR adds `np.atleast_2d` to add an extra dimension in these cases.

fixes #13 #11 