### PR TITLE
Add caching of ranks for computing RSA with Spearman

### DIFF
--- a/mne_rsa/rsa.py
+++ b/mne_rsa/rsa.py
@@ -156,7 +156,6 @@ def rsa_gen(rdm_data_gen, rdm_model, metric="spearman", ignore_nan=False):
         return_array = False
         rdm_model = [_ensure_condensed(rdm_model, "rdm_model")]
 
-
     if ignore_nan:
         masks = [~np.isnan(rdm) for rdm in rdm_model]
     else:
@@ -188,7 +187,9 @@ def _rsa_single_rdm(rdm_data, rdm_model, metric, masks, ignore_nan):
             ]
         else:
             rsa_vals = [
-                np.corrcoef(stats.rankdata(rdm_data), stats.rankdata(rdm_model_[mask]))[0, 1]
+                np.corrcoef(
+                    stats.rankdata(rdm_data[mask]), stats.rankdata(rdm_model_[mask])
+                )[0, 1]
                 for rdm_model_, mask in zip(rdm_model, masks)
             ]
     elif metric == "pearson":

--- a/mne_rsa/rsa.py
+++ b/mne_rsa/rsa.py
@@ -186,7 +186,7 @@ def _rsa_single_rdm(rdm_data, rdm_model, metric, masks, cache_ranks):
         if cache_ranks:
             rdm_data = stats.rankdata(rdm_data)
             rsa_vals = [
-                np.corrcoef(rdm_data, rdm_model_[mask])[0,1]
+                np.corrcoef(rdm_data, rdm_model_[mask])[0, 1]
                 for rdm_model_, mask in zip(rdm_model, masks)
             ]
         else:

--- a/mne_rsa/rsa.py
+++ b/mne_rsa/rsa.py
@@ -188,7 +188,7 @@ def _rsa_single_rdm(rdm_data, rdm_model, metric, masks, ignore_nan):
             ]
         else:
             rsa_vals = [
-                stats.spearmanr(rdm_data[mask], rdm_model_[mask])[0]
+                np.corrcoef(stats.rankdata(rdm_data), stats.rankdata(rdm_model_[mask]))[0, 1]
                 for rdm_model_, mask in zip(rdm_model, masks)
             ]
     elif metric == "pearson":


### PR DESCRIPTION
I have added a cache_ranks flag to rsa_gen and rsa_array to enable caching of ranks for model RDMs when computing RSA with Spearman. For now, the ignore_nan=True case is ignored and an error is raised when cache_ranks is used with it. 