### PR TITLE
Automatically build stable docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  release:
+    types: [published]
 
 jobs:
   doc-build:


### PR DESCRIPTION
This should allow github actions to built a new stable version of the docs whenever we release a new version. But how do we test this?